### PR TITLE
Fix: change filter’s option -p into —prompt

### DIFF
--- a/functions/__anyfff_finder.fish
+++ b/functions/__anyfff_finder.fish
@@ -3,10 +3,10 @@
 # multiple select> __anyfff_finder -m 'prompt message[multi] > '
 function __anyfff_finder -a single_or_multi prompt
   if [ $single_or_multi = '-s' ]
-    eval "$ANYFFF__FINDER_APP -p '$prompt'"
+    eval "$ANYFFF__FINDER_APP --prompt '$prompt'"
 
   else
-    eval "$ANYFFF__FINDER_APP -p '$prompt' $ANYFFF__FINDER_APP_OPTION_MULTIPLE" \
+    eval "$ANYFFF__FINDER_APP --prompt '$prompt' $ANYFFF__FINDER_APP_OPTION_MULTIPLE" \
       | __anyfff_util last \
       | xargs
   end


### PR DESCRIPTION
Hi!

Your anyfff is so helpful because I am just looking for something like anyframe or enhancd in fish-shell.

I use `peco` as a selector tool but `peco` do not recognize `-p` option.
So I rewrite the short option `-p` into long one `--prompt`.

Most of selector tools such as `sk`, `fzy`, and `fzf` have both of the long option `--prompt` and short one `-p`.
So I think this change do not cause problems in most cases.